### PR TITLE
Update visitor tracking code across all pages

### DIFF
--- a/site/about.html
+++ b/site/about.html
@@ -48,15 +48,16 @@
     <!-- Stylesheet -->
     <link rel="stylesheet" href="./styles.css">
 
-    <script async defer src='https://app.visitortracking.com/assets/js/tracer.js'></script>
+    <script async defer src="https://app.visitortracking.com/assets/js/tracer.js" > </script>
     <script>
-    function init_tracer() {
+      function init_tracer() {
        var tracer = new Tracer({
-       websiteId : "e5a88d02-174e-4f1b-ba13-1197f049cb2a",
-       async : true,
-       debug : false });
-     }
-     </script>
+        websiteId : '99cea56b-2ec5-47b8-9886-370426a9715e',
+        async : true,
+        debug : false
+       });
+    }
+    </script>
 </head>
 <body>
     <!-- Skip to main content link for keyboard navigation -->

--- a/site/blog-posts/script-template-google-docs.html
+++ b/site/blog-posts/script-template-google-docs.html
@@ -41,15 +41,16 @@
     <!-- Stylesheet -->
     <link rel="stylesheet" href="../styles.css">
 
-    <script async defer src='https://app.visitortracking.com/assets/js/tracer.js'></script>
+    <script async defer src="https://app.visitortracking.com/assets/js/tracer.js" > </script>
     <script>
-    function init_tracer() {
+      function init_tracer() {
        var tracer = new Tracer({
-       websiteId : "e5a88d02-174e-4f1b-ba13-1197f049cb2a",
-       async : true,
-       debug : false });
-     }
-     </script>
+        websiteId : '99cea56b-2ec5-47b8-9886-370426a9715e',
+        async : true,
+        debug : false
+       });
+    }
+    </script>
 </head>
 <body>
     <!-- Skip to main content link for keyboard navigation -->

--- a/site/blog.html
+++ b/site/blog.html
@@ -37,15 +37,16 @@
     <!-- Stylesheet -->
     <link rel="stylesheet" href="./styles.css">
 
-    <script async defer src='https://app.visitortracking.com/assets/js/tracer.js'></script>
+    <script async defer src="https://app.visitortracking.com/assets/js/tracer.js" > </script>
     <script>
-    function init_tracer() {
+      function init_tracer() {
        var tracer = new Tracer({
-       websiteId : "e5a88d02-174e-4f1b-ba13-1197f049cb2a",
-       async : true,
-       debug : false });
-     }
-     </script>
+        websiteId : '99cea56b-2ec5-47b8-9886-370426a9715e',
+        async : true,
+        debug : false
+       });
+    }
+    </script>
 </head>
 <body>
     <!-- Skip to main content link for keyboard navigation -->

--- a/site/index.html
+++ b/site/index.html
@@ -48,15 +48,16 @@
     <!-- Stylesheet -->
     <link rel="stylesheet" href="./styles.css">
 
-    <script async defer src='https://app.visitortracking.com/assets/js/tracer.js'></script>
+    <script async defer src="https://app.visitortracking.com/assets/js/tracer.js" > </script>
     <script>
-    function init_tracer() {
+      function init_tracer() {
        var tracer = new Tracer({
-       websiteId : "e5a88d02-174e-4f1b-ba13-1197f049cb2a",
-       async : true,
-       debug : false });
-     }
-     </script>
+        websiteId : '99cea56b-2ec5-47b8-9886-370426a9715e',
+        async : true,
+        debug : false
+       });
+    }
+    </script>
 </head>
 <body>
     <!-- Skip to main content link for keyboard navigation -->

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -37,15 +37,16 @@
     <!-- Stylesheet -->
     <link rel="stylesheet" href="./styles.css">
 
-    <script async defer src='https://app.visitortracking.com/assets/js/tracer.js'></script>
+    <script async defer src="https://app.visitortracking.com/assets/js/tracer.js" > </script>
     <script>
-    function init_tracer() {
+      function init_tracer() {
        var tracer = new Tracer({
-       websiteId : "e5a88d02-174e-4f1b-ba13-1197f049cb2a",
-       async : true,
-       debug : false });
-     }
-     </script>
+        websiteId : '99cea56b-2ec5-47b8-9886-370426a9715e',
+        async : true,
+        debug : false
+       });
+    }
+    </script>
 </head>
 <body>
     <!-- Skip to main content link for keyboard navigation -->

--- a/site/terms.html
+++ b/site/terms.html
@@ -37,15 +37,16 @@
     <!-- Stylesheet -->
     <link rel="stylesheet" href="./styles.css">
 
-    <script async defer src='https://app.visitortracking.com/assets/js/tracer.js'></script>
+    <script async defer src="https://app.visitortracking.com/assets/js/tracer.js" > </script>
     <script>
-    function init_tracer() {
+      function init_tracer() {
        var tracer = new Tracer({
-       websiteId : "e5a88d02-174e-4f1b-ba13-1197f049cb2a",
-       async : true,
-       debug : false });
-     }
-     </script>
+        websiteId : '99cea56b-2ec5-47b8-9886-370426a9715e',
+        async : true,
+        debug : false
+       });
+    }
+    </script>
 </head>
 <body>
     <!-- Skip to main content link for keyboard navigation -->


### PR DESCRIPTION
Replace old websiteId with new tracking ID (99cea56b-2ec5-47b8-9886-370426a9715e) in visitor tracking script across all HTML pages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces the tracer websiteId with a new ID and standardizes the tracking script/init across all pages.
> 
> - **Analytics/Tracking**:
>   - Update `Tracer` config `websiteId` to `99cea56b-2ec5-47b8-9886-370426a9715e` and standardize script tag/init function.
>   - Affected pages:
>     - `site/index.html`, `site/about.html`, `site/blog.html`, `site/privacy.html`, `site/terms.html`
>     - `site/blog-posts/script-template-google-docs.html`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b626a6036fd82b2397546bbc85aabd3cc315252. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->