### PR TITLE
Fix blog post not resolving by copying blog-posts directory to Docker…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM caddy:alpine
 COPY ./site/*.html /srv/
 COPY ./site/*.css /srv/
 COPY ./site/images/ /srv/images/
+COPY ./site/blog-posts/ /srv/blog-posts/
 
 # Copy Caddyfile
 COPY ./Caddyfile /etc/caddy/Caddyfile


### PR DESCRIPTION
… image

The Dockerfile only copied HTML files from the site root using *.html glob, which excluded the blog-posts subdirectory. Added explicit COPY instruction to include blog-posts/ in the deployed container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a COPY step in the Dockerfile to include `site/blog-posts/` in `/srv/blog-posts/` so blog posts resolve.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b035c9e9a780eb5d3b1c8440fa3aeef638db8546. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->